### PR TITLE
[IMP] Allow using generic fields through pivotParams

### DIFF
--- a/src/app/Classes/OptionsBuilder.php
+++ b/src/app/Classes/OptionsBuilder.php
@@ -76,9 +76,13 @@ class OptionsBuilder implements Responsable
         }
 
         collect(json_decode($this->request->get('pivotParams')))
-            ->each(function ($param, $table) {
-                $this->query->whereHas($table, function ($query) use ($param) {
-                    $query->whereIn('id', (array) $param->id);
+            ->each(function ($param, $relation) {
+                $this->query->whereHas($relation, function ($query) use ($param) {
+                    collect($param)->each(
+                        function ($value, $attribute) use ($query) {
+                            $query->whereIn($attribute, (array) $value);
+                        }
+                    );
                 });
             });
 


### PR DESCRIPTION
It appears that current `pivotParams` implementation does not handle fields other than `id` through given relation names. Though, speaking from [official documentation](https://docs.laravel-enso.com/packages/select.html#usage), this wasn't the intended behavior :slightly_smiling_face: 
Here's the fix to it.
