### PR TITLE
Hide dropdown-menu when reloading

### DIFF
--- a/src/resources/js/components/enso/select/VueSelect.vue
+++ b/src/resources/js/components/enso/select/VueSelect.vue
@@ -11,6 +11,9 @@
                 @focus="showDropdown">
                 <div class="select-value">
                     <div class="field is-grouped is-grouped-multiline">
+                        <span v-if="reloading && dropdown">
+                            {{ i18n(labels.loading) }}
+                        </span>
                         <div class="control"
                             v-if="multiple">
                             <tag v-for="option in selection"

--- a/src/resources/js/components/enso/select/VueSelect.vue
+++ b/src/resources/js/components/enso/select/VueSelect.vue
@@ -30,10 +30,13 @@
                             v-if="dropdown">
                     </div>
                     <div v-if="!dropdown">
-                        <span v-if="!multiple && hasSelection">
+                        <span v-if="reloading">
+                            {{ i18n(labels.loading) }}
+                        </span>
+                        <span v-else-if="!multiple && hasSelection">
                             {{ selection }}
                         </span>
-                        <span v-if="!hasSelection && hasOptions">
+                        <span v-else-if="!hasSelection && hasOptions">
                             {{ i18n(placeholder) }}
                         </span>
                         <span v-else-if="!hasOptions">
@@ -158,6 +161,7 @@ export default {
             default: () => ({
                 select: 'select',
                 deselect: 'deselect',
+                loading: 'Loading...',
                 noOptions: 'No options available',
                 noResults: 'No search results found',
                 addTag: 'Add option',
@@ -310,16 +314,18 @@ export default {
                 return;
             }
 
-            if(!queryData)
+            if(!queryData) {
                 this.reloading = true;
+            }
             this.loading = true;
 
             axios.get(this.path, { params: this.requestParams() })
                 .then(({ data }) => {
                     this.processOptions(data);
                     this.$emit('fetch', this.optionList);
-                    if(!queryData)
+                    if(!queryData) {
                         this.reloading = false;
+                    }
                     this.loading = false;
                 }).catch(error => this.errorHandler(error));
         },

--- a/src/resources/js/components/enso/select/VueSelect.vue
+++ b/src/resources/js/components/enso/select/VueSelect.vue
@@ -52,7 +52,7 @@
                 </div>
             </fieldset>
         </div>
-        <div class="dropdown-menu">
+        <div class="dropdown-menu" v-if="!reloading">
             <div class="dropdown-content">
                 <a class="dropdown-item"
                     v-for="(option, index) in filteredOptions"
@@ -216,6 +216,7 @@ export default {
     data: v => ({
         optionList: v.options,
         loading: false,
+        reloading: false,
         query: '',
         dropdown: false,
         position: null,
@@ -304,17 +305,21 @@ export default {
                 ? route(this.source)
                 : this.source;
         },
-        fetch() {
+        fetch(queryData) {
             if (!this.isServerSide) {
                 return;
             }
 
+            if(!queryData)
+                this.reloading = true;
             this.loading = true;
 
             axios.get(this.path, { params: this.requestParams() })
                 .then(({ data }) => {
                     this.processOptions(data);
                     this.$emit('fetch', this.optionList);
+                    if(!queryData)
+                        this.reloading = false;
                     this.loading = false;
                 }).catch(error => this.errorHandler(error));
         },


### PR DESCRIPTION
hides the dropdown-menu when reloading (non-query related fetch)

f.e. changed parameter which might invalidate _cached_ options