### PR TITLE
Prevent crash when existing value is unavailable

### DIFF
--- a/src/resources/js/components/enso/select/VueSelect.vue
+++ b/src/resources/js/components/enso/select/VueSelect.vue
@@ -256,7 +256,7 @@ export default {
             const option = this.optionList
                 .find(option => option[this.trackBy] === this.value);
 
-            return this.optionLabel(option);
+            return option ? this.optionLabel(option) : null;
         },
     },
 


### PR DESCRIPTION
If the current selection is no longer a part of the valuelist, default label to null

i.e. when using a server-side form; editing an entry where the selected item id is no longer part of the options set currently crashes the VueSelect component.
Fallback to `null` instead